### PR TITLE
Fix for failed to fetch controller: unsupported controller kind StatefulSet

### DIFF
--- a/pspmutating.go
+++ b/pspmutating.go
@@ -73,6 +73,8 @@ func FetchControllerObj(kind, name, namespace string, clientset *kubernetes.Clie
 		return clientset.AppsV1().ReplicaSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	case "DaemonSet":
 		return clientset.AppsV1().DaemonSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	case "StatefulSet":
+		return clientset.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	default:
 		return nil, fmt.Errorf("unsupported controller kind %s", kind)
 	}


### PR DESCRIPTION
This is a fix for Issue #11 https://github.com/kubernetes-sigs/pspmigrator/issues/11